### PR TITLE
🔧 config: Eclipse 인코딩 설정(UTF-8) 충돌 정리 및 반영

### DIFF
--- a/.settings/org.eclipse.core.resources.prefs
+++ b/.settings/org.eclipse.core.resources.prefs
@@ -1,15 +1,2 @@
 eclipse.preferences.version=1
-<<<<<<< refactor/mapper-table-name-update
-<<<<<<< Updated upstream
-=======
-encoding//src/main/java/com/takku/project/mapper/SettlementMapper.java=UTF-8
-encoding//src/main/java/com/takku/project/mapper/StoreMapper.java=UTF-8
-encoding//src/main/java/com/takku/project/mapper/UserMapper.java=UTF-8
-encoding//src/main/java/com/takku/project/service/AIServiceImpl.java=UTF-8
->>>>>>> Stashed changes
 encoding/<project>=UTF-8
-=======
-encoding//src/main/java/com/takku/project/mapper/StoreMapper.java=UTF-8
-encoding//src/main/java/com/takku/project/mapper/UserMapper.java=UTF-8
-encoding//src/main/java/com/takku/project/service/AIServiceImpl.java=UTF-8
->>>>>>> develop


### PR DESCRIPTION
## 📌 PR 제목  
🔧 config: Eclipse 인코딩 설정(UTF-8) 충돌 정리 및 반영

## ✨ 주요 변경 사항  
- 전체 프로젝트 기본 인코딩을 `UTF-8`로 통일  

## 🙏 리뷰어에게 요청 사항  
- `.settings` 폴더를 `.gitignore`에 무시하고 있었지만, 충돌 해결을 위해 이번 커밋에 한해 강제로 포함했습니다.  
- 향후 `.settings` 관련 커밋을 방지하려면 `.gitignore`를 강화할 수도 있습니다.  
