### PR TITLE
✨ 리뷰 페이지에 Tiles 레이아웃 적용 및 컨트롤러 뷰 경로 통일

### DIFF
--- a/.settings/org.eclipse.core.resources.prefs
+++ b/.settings/org.eclipse.core.resources.prefs
@@ -2,3 +2,4 @@
 eclipse.preferences.version=1
 encoding//src/main/resources/application.properties=UTF-8
 encoding//src/main/webapp/WEB-INF/views/pages/user/review.jsp=UTF-8
+encoding/<project>=UTF-8

--- a/.settings/org.eclipse.core.resources.prefs
+++ b/.settings/org.eclipse.core.resources.prefs
@@ -2,4 +2,3 @@
 eclipse.preferences.version=1
 encoding//src/main/resources/application.properties=UTF-8
 encoding//src/main/webapp/WEB-INF/views/pages/user/review.jsp=UTF-8
-encoding/<project>=UTF-8

--- a/src/main/java/com/takku/project/controller/CouponController.java
+++ b/src/main/java/com/takku/project/controller/CouponController.java
@@ -2,10 +2,6 @@ package com.takku.project.controller;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
@@ -17,7 +13,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 
 import com.takku.project.domain.CouponDTO;
 import com.takku.project.domain.FundingDTO;
-import com.takku.project.mapper.FundingMapper;
 import com.takku.project.service.CouponService;
 import com.takku.project.service.FundingService;
 

--- a/src/main/java/com/takku/project/controller/FundingController.java
+++ b/src/main/java/com/takku/project/controller/FundingController.java
@@ -15,7 +15,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import com.takku.project.domain.FundingDTO;
 import com.takku.project.domain.ImageDTO;
 import com.takku.project.domain.ProductDTO;
-import com.takku.project.domain.StoreDTO;
 import com.takku.project.service.FundingService;
 import com.takku.project.service.ImageService;
 import com.takku.project.service.ProductService;

--- a/src/main/java/com/takku/project/controller/ReviewController.java
+++ b/src/main/java/com/takku/project/controller/ReviewController.java
@@ -43,7 +43,7 @@ public class ReviewController {
 
 		model.addAttribute("couponDTO", coupon);
 		model.addAttribute("fundingDTO", funding);
-		return "pages/user/review";
+		return "user.review";
 	}
 
 	// 리뷰 등록 처리 - JSON 응답

--- a/src/main/java/com/takku/project/controller/StoreController.java
+++ b/src/main/java/com/takku/project/controller/StoreController.java
@@ -1,6 +1,5 @@
 package com.takku.project.controller;
 
-import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;

--- a/src/main/java/com/takku/project/controller/UserController.java
+++ b/src/main/java/com/takku/project/controller/UserController.java
@@ -11,7 +11,6 @@ import com.takku.project.service.UserService;
 
 import java.util.List;
 
-import javax.servlet.http.HttpSession;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
@@ -20,7 +19,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 @Controller

--- a/src/main/java/com/takku/project/filter/GlobalExceptionHandler.java
+++ b/src/main/java/com/takku/project/filter/GlobalExceptionHandler.java
@@ -3,7 +3,6 @@ package com.takku.project.filter;
 import com.takku.project.errorcode.ErrorCode;
 import com.takku.project.exception.BusinessException;
 import com.takku.project.util.ErrorResponse;
-import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.servlet.ModelAndView;
 

--- a/src/main/java/com/takku/project/mapper/StoreMapper.java
+++ b/src/main/java/com/takku/project/mapper/StoreMapper.java
@@ -1,6 +1,5 @@
 package com.takku.project.mapper;
 
-import java.util.List;
 
 import com.takku.project.domain.StoreDTO;
 

--- a/src/main/java/com/takku/project/service/StoreService.java
+++ b/src/main/java/com/takku/project/service/StoreService.java
@@ -1,6 +1,5 @@
 package com.takku.project.service;
 
-import java.util.List;
 
 import org.apache.ibatis.session.SqlSession;
 

--- a/src/main/webapp/WEB-INF/tiles.xml
+++ b/src/main/webapp/WEB-INF/tiles.xml
@@ -43,6 +43,12 @@
 			value="/WEB-INF/views/pages/user/mypage.jsp" />
 	</definition>
 
+	<!-- 리뷰 작성 페이지 -->
+	<definition name="user.review"
+		template="/WEB-INF/views/pages/user/review.jsp" />
+
+
+
 	<!-- 에러 -->
 	<definition name="error.error" extends="defaultLayout">
 		<put-attribute name="title" value="에러 페이지" />

--- a/src/main/webapp/WEB-INF/views/pages/user/funding_detail.jsp
+++ b/src/main/webapp/WEB-INF/views/pages/user/funding_detail.jsp
@@ -9,13 +9,13 @@
 	href="${pageContext.request.contextPath}/resources/css/common/style.css">
 </head>
 <body>
-	<%@ include file="/WEB-INF/views/common/components/header.jsp"%>
+	<%@ include file="/WEB-INF/views/layout/main-header.jsp"%>
 	<div class="container">
 		<div class="content">
 		<label>Home / ${store.categoryName}</label>
 		</div>
 
-		<%@ include file="/WEB-INF/views/common/components/footer.jsp"%>
+		<%@ include file="/WEB-INF/views/layout/footer.jsp"%>
 	</div>
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/views/pages/user/mypage.jsp
+++ b/src/main/webapp/WEB-INF/views/pages/user/mypage.jsp
@@ -12,7 +12,7 @@
 
 </head>
 <body>
-	<%@ include file="/WEB-INF/views/common/components/header.jsp"%>
+	<%@ include file="/WEB-INF/views/layout/main-header.jsp"%>
 	<div class="container">
 
 		<div class="mypage-container">
@@ -45,7 +45,7 @@
 
 
 
-		<%@ include file="/WEB-INF/views/common/components/footer.jsp"%>
+		<%@ include file="/WEB-INF/views/layout/footer.jsp"%>
 	</div>
 </body>
 </html>

--- a/src/test/java/com/takku/project/serviceTest/FundingServiceTest.java
+++ b/src/test/java/com/takku/project/serviceTest/FundingServiceTest.java
@@ -5,9 +5,7 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.apache.ibatis.session.SqlSession;
 import org.junit.jupiter.api.BeforeEach;


### PR DESCRIPTION
## ✨ 주요 변경 사항  
- `ReviewController`의 뷰 리턴값을 Tiles 레이아웃과 호환되도록 경로 수정  
- `tiles.xml`에 리뷰 페이지에 대응하는 정의 추가  
- 기존의 직접 JSP 접근 방식에서 Tiles 기반 뷰 관리 방식으로 통일

## 🧪 테스트 결과  
- [x] 정상 동작 확인 (리뷰 작성 페이지 렌더링 정상)  

## 🙏 리뷰어에게 요청 사항  
- `tiles.xml` 정의 이름 컨벤션이 괜찮은지 확인 부탁드립니다  
- 추후 다른 페이지도 Tiles 적용 시 참고될 수 있으므로 구조 피드백 환영합니다
