### PR TITLE
🐛 fix: 메뉴 수정 후 펀딩 폼에 선택된 메뉴 유지되도록 로직 개선

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,13 +64,6 @@
 			<scope>test</scope>
 		</dependency>
 
-		<!-- Mockito + JUnit5 연동: MockitoExtension 포함 -->
-		<dependency>
-			<groupId>org.mockito</groupId>
-			<artifactId>mockito-junit-jupiter</artifactId>
-			<version>5.2.0</version>
-			<scope>test</scope>
-		</dependency>
 		<!-- Spring Test -->
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -335,19 +328,17 @@
 	<build>
 		<plugins>
 			<plugin>
-				<artifactId>maven-eclipse-plugin</artifactId>
-				<version>2.9</version>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.11.0</version>
 				<configuration>
-					<additionalProjectnatures>
-						<projectnature>org.springframework.ide.eclipse.core.springnature
-						</projectnature>
-					</additionalProjectnatures>
-					<additionalBuildcommands>
-						<buildcommand>org.springframework.ide.eclipse.core.springbuilder
-						</buildcommand>
-					</additionalBuildcommands>
-					<downloadSources>true</downloadSources>
-					<downloadJavadocs>true</downloadJavadocs>
+					<source>11</source>
+					<target>11</target>
+					<compilerArgs>
+						<arg>-Xlint:all</arg>
+					</compilerArgs>
+					<showWarnings>true</showWarnings>
+					<showDeprecation>true</showDeprecation>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/src/main/java/com/takku/project/controller/ProductManagementController.java
+++ b/src/main/java/com/takku/project/controller/ProductManagementController.java
@@ -63,130 +63,123 @@ public class ProductManagementController {
 	public String showForm() {
 		return "seller.product";
 	}
-	
+
 	private String getFileExtension(String filename) {
-	    if (filename == null || !filename.contains(".")) {
-	        return "";
-	    }
-	    return filename.substring(filename.lastIndexOf("."));
+		if (filename == null || !filename.contains(".")) {
+			return "";
+		}
+		return filename.substring(filename.lastIndexOf("."));
 	}
 
 	// 상품 등록 & 이미지 저장
 	@PostMapping(value = "/insert", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
 	@ResponseBody
-	public ResponseEntity<String> insertProductWithImages(
-	        @RequestParam("product") String productJson,
-	        @RequestPart(value = "images", required = false) MultipartFile[] files) {
+	public ResponseEntity<String> insertProductWithImages(@RequestParam("product") String productJson,
+			@RequestPart(value = "images", required = false) MultipartFile[] files) {
 
-	    try {
-	        ObjectMapper mapper = new ObjectMapper();
-	        ProductDTO productDTO = mapper.readValue(productJson, ProductDTO.class);
+		try {
+			ObjectMapper mapper = new ObjectMapper();
+			ProductDTO productDTO = mapper.readValue(productJson, ProductDTO.class);
 
-	        if (productDTO.getStoreId() == null) {
-	            productDTO.setStoreId(1);
-	        }
+			if (productDTO.getStoreId() == null) {
+				productDTO.setStoreId(1);
+			}
 
-	        // 상품 등록
-	        int result = productService.insertProduct(productDTO);
+			// 상품 등록
+			int result = productService.insertProduct(productDTO);
 
-	        // 이미지 저장
-	        if (result > 0) {
-	            imageService.storeImages(files, productDTO.getProductId(), null, null);
-	        }
+			// 이미지 저장
+			if (result > 0) {
+				imageService.storeImages(files, productDTO.getProductId(), null, null);
+			}
 
-	        return ResponseEntity.ok("상품 등록 성공");
+			return ResponseEntity.ok("상품 등록 성공");
 
-	    } catch (Exception e) {
-	        e.printStackTrace();
-	        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("오류 발생: " + e.getMessage());
-	    }
+		} catch (Exception e) {
+			e.printStackTrace();
+			return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("오류 발생: " + e.getMessage());
+		}
 	}
-
 
 	// 상품 수정 폼
 	@GetMapping("/edit/{productId}")
-	public String showEditForm(@PathVariable("productId") Integer productId, Model model) {
+	public String showEditForm(@PathVariable("productId") Integer productId,
+			@RequestParam(value = "redirect", required = false) String redirect, Model model) {
 		ProductDTO productDTO = productService.selectByProductId(productId);
 		model.addAttribute("productDTO", productDTO);
-		return "seller.product";
+
+		if (redirect != null) {
+			model.addAttribute("redirectUrl", redirect);
+		}
+
+		return "seller.product"; 
 	}
 
 	// 상품 수정 처리
 	@PostMapping(value = "/update/{productId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
 	@ResponseBody
-	public String updateProductWithImages(
-	    @PathVariable("productId") Integer productId,
-	    @RequestParam("product") String productJson,
-	    @RequestPart(value = "images", required = false) MultipartFile[] files
-	) {
-	    try {
-	        ObjectMapper mapper = new ObjectMapper();
-	        ProductDTO productDTO = mapper.readValue(productJson, ProductDTO.class);
-	        productDTO.setProductId(productId);
+	public String updateProductWithImages(@PathVariable("productId") Integer productId,
+			@RequestParam("product") String productJson,
+			@RequestPart(value = "images", required = false) MultipartFile[] files) {
+		try {
+			ObjectMapper mapper = new ObjectMapper();
+			ProductDTO productDTO = mapper.readValue(productJson, ProductDTO.class);
+			productDTO.setProductId(productId);
 
-	        int result = productService.updateProduct(productDTO);
+			int result = productService.updateProduct(productDTO);
 
-	        List<ImageDTO> existingImages = imageService.selectImagesByProductId(productId);
-	        List<String> existingUrls = existingImages.stream()
-	            .map(ImageDTO::getImageUrl)
-	            .collect(Collectors.toList());
+			List<ImageDTO> existingImages = imageService.selectImagesByProductId(productId);
+			List<String> existingUrls = existingImages.stream().map(ImageDTO::getImageUrl).collect(Collectors.toList());
 
-	        List<String> newUrls = productDTO.getImages() != null
-	            ? productDTO.getImages().stream()
-	                .map(ImageDTO::getImageUrl)
-	                .collect(Collectors.toList())
-	            : new ArrayList<>();
+			List<String> newUrls = productDTO.getImages() != null
+					? productDTO.getImages().stream().map(ImageDTO::getImageUrl).collect(Collectors.toList())
+					: new ArrayList<>();
 
-	        for (String oldUrl : existingUrls) {
-	            if (!newUrls.contains(oldUrl)) {
-	                imageService.deleteImageUrl(oldUrl);
-	            }
-	        }
+			for (String oldUrl : existingUrls) {
+				if (!newUrls.contains(oldUrl)) {
+					imageService.deleteImageUrl(oldUrl);
+				}
+			}
 
-	        if (files != null) {
-	            for (MultipartFile file : files) {
-	                if (!file.isEmpty()) {
-	                    String ext = getFileExtension(file.getOriginalFilename());
-	                    String fileName = UUID.randomUUID().toString() + ext;
+			if (files != null) {
+				for (MultipartFile file : files) {
+					if (!file.isEmpty()) {
+						String ext = getFileExtension(file.getOriginalFilename());
+						String fileName = UUID.randomUUID().toString() + ext;
 
-	                    File uploadPath = new File(uploadDir);
-	                    if (!uploadPath.exists()) uploadPath.mkdirs();
+						File uploadPath = new File(uploadDir);
+						if (!uploadPath.exists())
+							uploadPath.mkdirs();
 
-	                    File dest = new File(uploadDir + File.separator + fileName);
-	                    file.transferTo(dest);
+						File dest = new File(uploadDir + File.separator + fileName);
+						file.transferTo(dest);
 
-	                    ImageDTO image = ImageDTO.builder()
-	                        .productId(productId)
-	                        .imageUrl("/image/" + fileName)
-	                        .build();
+						ImageDTO image = ImageDTO.builder().productId(productId).imageUrl("/image/" + fileName).build();
 
-	                    imageService.insertImageUrl(image);
-	                }
-	            }
-	        }
+						imageService.insertImageUrl(image);
+					}
+				}
+			}
 
-	        for (String newUrl : newUrls) {
-	            if (newUrl == null) continue;
-	            if (!existingUrls.contains(newUrl)) {
-	                String correctedUrl = newUrl.startsWith("/image/") ? newUrl : "/image/" + newUrl;
+			for (String newUrl : newUrls) {
+				if (newUrl == null)
+					continue;
+				if (!existingUrls.contains(newUrl)) {
+					String correctedUrl = newUrl.startsWith("/image/") ? newUrl : "/image/" + newUrl;
 
-	                ImageDTO image = ImageDTO.builder()
-	                    .productId(productId)
-	                    .imageUrl(correctedUrl)
-	                    .build();
+					ImageDTO image = ImageDTO.builder().productId(productId).imageUrl(correctedUrl).build();
 
-	                imageService.insertImageUrl(image);
-	            }
-	        }
+					imageService.insertImageUrl(image);
+				}
+			}
 
-	        return result > 0 ? "상품이 수정되었습니다." : "상품 수정에 실패하였습니다.";
+			return result > 0 ? "상품이 수정되었습니다." : "상품 수정에 실패하였습니다.";
 
-	    } catch (Exception e) {
-	        e.printStackTrace();
-	        return "오류 발생: " + e.getMessage();
-	    }
+		} catch (Exception e) {
+			e.printStackTrace();
+			return "오류 발생: " + e.getMessage();
+		}
 	}
-
 
 	// 상품 삭제
 	@DeleteMapping("/{productId}")

--- a/src/main/webapp/WEB-INF/views/pages/seller/create_existMenu.jsp
+++ b/src/main/webapp/WEB-INF/views/pages/seller/create_existMenu.jsp
@@ -7,87 +7,110 @@
 <script>
 let basePrice = null;
 
-$(document).ready(function() {
-  // 메뉴 목록 불러오기
-  $('#menuSelect').on('focus', function() {
-    const storeId = ${storeDTO.storeId};
+function getSelectedProductIdFromURL() {
+  const params = new URLSearchParams(window.location.search);
+  return params.get('selectedProductId');
+}
 
-    $.ajax({
-      url: '${pageContext.request.contextPath}/seller/product/list',
-      method: 'GET',
-      data: { storeId: storeId },
-      success: function(productList) {
-        $('#menuSelect').html('<option value="" disabled selected>메뉴를 선택해주세요.</option>');
-        $.each(productList, function(i, product) {
-          $('#menuSelect').append(
-            $('<option></option>').val(product.productId).text(product.productName)
-          );
-        });
+$(document).ready(function () {
+  const storeId = ${storeDTO.storeId};
+  const selectedId = getSelectedProductIdFromURL();
+
+  // 메뉴 목록 불러오기
+  $.ajax({
+    url: '${pageContext.request.contextPath}/seller/product/list',
+    method: 'GET',
+    data: { storeId: storeId },
+    success: function(productList) {
+      $('#menuSelect').html('<option value="" disabled selected>메뉴를 선택해주세요.</option>');
+      $.each(productList, function(i, product) {
+        const option = $('<option></option>').val(product.productId).text(product.productName);
+        if (selectedId && product.productId == selectedId) {
+          option.prop('selected', true);
+        }
+        $('#menuSelect').append(option);
+      });
+
+      if (selectedId) {
+        $('#menuSelect').trigger('change');
+        history.replaceState({}, document.title, window.location.pathname); // URL 깔끔하게
       }
-    });
+    }
   });
 
-  // 상품 선택 시 가격 정보 표시 및 할인율 계산 준비
-  $('#menuSelect').on('change', function() {
+  // 정가 불러오기
+  $('#menuSelect').on('change', function () {
     const productId = $(this).val();
     $.ajax({
       url: '${pageContext.request.contextPath}/seller/product/info',
       method: 'GET',
       data: { productId: productId },
       dataType: 'json',
-      success: function(product) {
+      success: function (product) {
         if (product && product.price != null) {
           basePrice = product.price;
           $('#menuPrice').attr('placeholder', basePrice);
           $('#menuPrice').val('');
           $('#discountRate').text('할인율은 %입니다.');
+          updateMinPrice();
+        } else {
+          basePrice = null;
+          $('#menuPrice').attr('placeholder', '가격 정보를 불러오지 못했습니다.');
         }
       }
     });
   });
 
-  // 판매가 입력 시 할인율 계산
-  $('#menuPrice').on('input', function() {
+  // 할인율 계산
+  $('#menuPrice').on('input', function () {
     const sellingPrice = Number($(this).val());
-
     if (basePrice && sellingPrice > 0 && sellingPrice <= basePrice) {
       let discount = ((1 - (sellingPrice / basePrice)) * 100).toFixed(1);
-      $('#discountRate').text(`할인율은 \${discount}%입니다.`);
+      $('#discountRate').text(`할인율은 ${discount}%입니다.`);
     } else if (sellingPrice > basePrice) {
       $('#discountRate').text('판매가는 정가보다 클 수 없습니다.');
+    } else {
+      $('#discountRate').text('할인율은 %입니다.');
     }
+    updateMinPrice();
   });
 
-  // 판매가가 정가보다 높을 경우 form 제출 방지
-  $('form').on('submit', function(e) {
+  // 최소 펀딩 금액 계산
+  $('#minSales').on('input', updateMinPrice);
+
+  function updateMinPrice() {
+    const price = Number($('#menuPrice').val());
+    const quantity = Number($('#minSales').val());
+    const minAmount = price > 0 && quantity > 0 ? price * quantity : 0;
+    $('#amount').text(minAmount.toLocaleString());
+  }
+
+  // 정가보다 높은 경우 차단
+  $('form').on('submit', function (e) {
     const sellingPrice = Number($('#menuPrice').val());
     if (basePrice && sellingPrice > basePrice) {
       e.preventDefault();
       $('#resultModal, #modalBackdrop').fadeIn();
     }
   });
-  
-	//모달 닫기 및 포커스 이동
- 	$('#closeModalBtn').on('click', function () {
+
+  $('#closeModalBtn').on('click', function () {
     $('#resultModal, #modalBackdrop').fadeOut();
-    $('#menuPrice').focus(); // 판매가 입력 칸으로 포커스 이동
+    $('#menuPrice').focus();
   });
-	
-	
-$(document).on('click', '#btn-edit', function(){
-	const productId = $('#menuSelect').val();
-	
-	if(productId) {
-		window.location.href='${pageContext.request.contextPath}/seller/product/' + productId + '/edit';
-	}else {
-		alert("수정할 메뉴를 선택해주세요");
-	}
+
+  // 수정 버튼 클릭 시 redirect 포함
+  $('#btn-edit').on('click', function () {
+    const productId = $('#menuSelect').val();
+    if (productId) {
+      const redirectUrl = encodeURIComponent(window.location.pathname + '?type=limited&selectedProductId=' + productId);
+      const base = '${pageContext.request.contextPath}';
+      window.location.href = base + '/seller/product/edit/' + productId + '?redirect=' + redirectUrl;
+    } else {
+      alert('수정할 메뉴를 선택해주세요.');
+    }
+  });
 });
-});
-
-	
-
-
 </script>
 
 <div class="step-progress">

--- a/src/main/webapp/WEB-INF/views/pages/seller/create_normalFunding.jsp
+++ b/src/main/webapp/WEB-INF/views/pages/seller/create_normalFunding.jsp
@@ -1,36 +1,44 @@
-<%@ page language="java" contentType="text/html; charset=UTF-8"
-	pageEncoding="UTF-8"%>
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
-
+<%@ include file="/WEB-INF/views/common/init.jsp"%>
 <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 <link rel="stylesheet" href="${pageContext.request.contextPath}/resources/css/pages/seller/createFunding_exist_normal.css">
 
 <script>
 let basePrice = null;
 
+function getSelectedProductIdFromURL() {
+  const params = new URLSearchParams(window.location.search);
+  return params.get('selectedProductId');
+}
+
 $(document).ready(function () {
+  const storeId = ${storeDTO.storeId};
+  const selectedId = getSelectedProductIdFromURL();
 
   // 메뉴 목록 불러오기
-$('#menuSelect').on('focus', function() {
-    const storeId = ${storeDTO.storeId}; 
+  $.ajax({
+    url: '${pageContext.request.contextPath}/seller/product/list',
+    method: 'GET',
+    data: { storeId: storeId },
+    success: function(productList) {
+      $('#menuSelect').html('<option value="" disabled selected>메뉴를 선택해주세요.</option>');
+      $.each(productList, function(i, product) {
+        const option = $('<option></option>').val(product.productId).text(product.productName);
+        if (selectedId && product.productId == selectedId) {
+          option.prop('selected', true);
+        }
+        $('#menuSelect').append(option);
+      });
 
-    $.ajax({
-      url: '${pageContext.request.contextPath}/seller/product/list',
-      method: 'GET',
-      data: { storeId: storeId },
-      success: function(productList) {
-        $('#menuSelect').html('<option value="" disabled selected>메뉴를 선택해주세요.</option>');
-        $.each(productList, function(i, product) {
-          $('#menuSelect').append(
-            $('<option></option>').val(product.productId).text(product.productName)
-          );
-        });
+      if (selectedId) {
+        $('#menuSelect').trigger('change');
+        history.replaceState({}, document.title, window.location.pathname); // 파라미터 제거
       }
-    });
+    }
   });
 
-
-  // 메뉴 선택 시 정가 불러오기 + basePrice 저장
+  // 정가 불러오기
   $('#menuSelect').on('change', function () {
     const productId = $(this).val();
     $.ajax({
@@ -44,7 +52,7 @@ $('#menuSelect').on('focus', function() {
           $('#menuPrice').attr('placeholder', basePrice);
           $('#menuPrice').val('');
           $('#discountRate').text('할인율은 %입니다.');
-          updateMinPrice(); // 정가 변경되면 최소금액도 다시 계산
+          updateMinPrice();
         } else {
           basePrice = null;
           $('#menuPrice').attr('placeholder', '가격 정보를 불러오지 못했습니다.');
@@ -56,10 +64,9 @@ $('#menuSelect').on('focus', function() {
   // 할인율 계산
   $('#menuPrice').on('input', function () {
     const sellingPrice = Number($(this).val());
-
     if (basePrice && sellingPrice > 0 && sellingPrice <= basePrice) {
       let discount = ((1 - (sellingPrice / basePrice)) * 100).toFixed(1);
-      $('#discountRate').text(`할인율은 \${discount}%입니다.`);
+      $('#discountRate').text(`할인율은 ${discount}%입니다.`);
     } else if (sellingPrice > basePrice) {
       $('#discountRate').text('판매가는 정가보다 클 수 없습니다.');
     } else {
@@ -68,22 +75,17 @@ $('#menuSelect').on('focus', function() {
     updateMinPrice();
   });
 
-  // 최소 펀딩 성공 금액 계산
+  // 최소 펀딩 금액 계산
   $('#minSales').on('input', updateMinPrice);
 
   function updateMinPrice() {
     const price = Number($('#menuPrice').val());
     const quantity = Number($('#minSales').val());
-
-    if (price > 0 && quantity > 0) {
-      const minAmount = price * quantity;
-      $('#amount').text(minAmount.toLocaleString());
-    } else {
-      $('#amount').text('0');
-    }
+    const minAmount = price > 0 && quantity > 0 ? price * quantity : 0;
+    $('#amount').text(minAmount.toLocaleString());
   }
 
-  // 제출 시 정가보다 높은 경우 차단
+  // 정가보다 높은 경우 차단
   $('form').on('submit', function (e) {
     const sellingPrice = Number($('#menuPrice').val());
     if (basePrice && sellingPrice > basePrice) {
@@ -91,102 +93,86 @@ $('#menuSelect').on('focus', function() {
       $('#resultModal, #modalBackdrop').fadeIn();
     }
   });
-  
-  //모달 닫기 및 포커스 이동
+
   $('#closeModalBtn').on('click', function () {
     $('#resultModal, #modalBackdrop').fadeOut();
-    $('#menuPrice').focus(); // 판매가 입력 칸으로 포커스 이동
+    $('#menuPrice').focus();
   });
-  
-$(document).on('click', '#btn-edit', function(){
-	const productId = $('#menuSelect').val();
-	
-	if(productId) {
-		window.location.href='${pageContext.request.contextPath}/seller/product/' + productId + '/edit';
-	}else {
-		alert("수정할 메뉴를 선택해주세요");
-	}
-});
-});
 
+  // 수정 버튼
+  $('#btn-edit').on('click', function () {
+    const productId = $('#menuSelect').val();
+    if (productId) {
+      const redirectUrl = encodeURIComponent(window.location.pathname + '?type=general&selectedProductId=' + productId);
+      const base = '${pageContext.request.contextPath}';
+      window.location.href = base + '/seller/product/edit/' + productId + '?redirect=' + redirectUrl;
+    } else {
+      alert("수정할 메뉴를 선택해주세요");
+    }
+  });
+});
 </script>
 
+<!-- 단계 표시 -->
 <div class="step-progress">
-  <div class="step active">
-    <div class="circle">1</div>
-    <div class="label">상품 정보</div>
-  </div>
+  <div class="step active"><div class="circle">1</div><div class="label">상품 정보</div></div>
   <div class="line"></div>
-  <div class="step">
-    <div class="circle">2</div>
-    <div class="label">기간 및 이미지</div>
-  </div>
+  <div class="step"><div class="circle">2</div><div class="label">기간 및 이미지</div></div>
   <div class="line"></div>
-  <div class="step">
-    <div class="circle">3</div>
-    <div class="label">상세 내용</div>
-  </div>
+  <div class="step"><div class="circle">3</div><div class="label">상세 내용</div></div>
 </div>
 
 <form action="${pageContext.request.contextPath}/seller/fundings/create-step3" method="post">
 	<div class="menuName">
 		<div class="menu-label">펀딩할 메뉴를 선택해주세요.</div>
 		<div class="menu-select">
-
 			<select id="menuSelect" name="productId" required>
 				<option value="" disabled selected>메뉴를 선택해주세요.</option>
 			</select>
-
 			<button type="button" class="btn-edit" id="btn-edit">정보 수정</button>
 			<button type="button" class="btn-add" onclick="location.href='${pageContext.request.contextPath}/seller/product/new'">메뉴 추가</button>
 		</div>
 		<div id="menu-list"></div>
 	</div>
 
-	<!-- 메뉴의 정가 입력 -->
 	<div class="menuPrice">
 		<div class="menu-label" name="fundingName">해당 메뉴를 얼마에 판매할지 판매가를 입력해주세요.</div>
-		<input type="number" id="menuPrice" placeholder="판매가 " name="salePrice" required class="form-input" /> <span class="unit-text">&nbsp원</span><br> <span
-			id="discountRate">할인율은 %입니다.</span>
+		<input type="number" id="menuPrice" placeholder="판매가 " name="salePrice" required class="form-input" />
+		<span class="unit-text">&nbsp원</span><br>
+		<span id="discountRate">할인율은 %입니다.</span>
 	</div>
 
-	<!-- 펀딩성공기준 -->
 	<div class="form-group">
 		<div class="menu-label">원하시는 최소 판매 개수를 입력해주세요. (펀딩 성공 기준)</div>
 		<div class="description">예: 30개를 목표로 하면, 30개가 팔려야 펀딩이 성공합니다.</div>
-		<input type="number" id="minSales" name=targetQty
-			placeholder="최소 판매 개수 입력" required class="form-input"/><span class="unit-text">&nbsp개</span><br>
+		<input type="number" id="minSales" name="targetQty" placeholder="최소 판매 개수 입력" required class="form-input"/>
+		<span class="unit-text">&nbsp개</span><br>
 		<span id="minPrice">펀딩 성공을 위한 최소 금액은 <span id="amount"></span>원입니다.</span>
 	</div>
 
-	<!-- 판매 가능한 최대 개수 -->
 	<div class="form-group">
 		<div class="menu-label">펀딩 이벤트로 판매 가능한 최대 개수를 입력해 주세요.</div>
 		<div class="description">예: 50개가 가능하면, 50개 판매시 사용자가 펀딩 참여 불가능합니다.</div>
-		<input type="number" id="maxSales" name="maxQty"
-			placeholder="최대 판매 개수 입력" required class="form-input"/> <span class="unit-text">&nbsp개</span>
+		<input type="number" id="maxSales" name="maxQty" placeholder="최대 판매 개수 입력" required class="form-input"/> 
+		<span class="unit-text">&nbsp개</span>
 	</div>
 
-	<!-- 한 사람이 구매할 수 있는 펀딩 개수 -->
 	<div class="form-group">
 		<div class="menu-label">한 사람이 최대 몇 개까지 살 수 있는지 정해주세요.</div>
 		<div class="description">예: 1명당 2개까지 구매 가능합니다.</div>
-		<input type="number" id="maxPerUser" name="perQty"
-			placeholder="인당 구매 가능 개수 입력" required class="form-input"/><span class="unit-text">&nbsp&nbsp개</span>
+		<input type="number" id="maxPerUser" name="perQty" placeholder="인당 구매 가능 개수 입력" required class="form-input"/>
+		<span class="unit-text">&nbsp&nbsp개</span>
 	</div>
-
 
 	<div class="btn-container">
 		<button class="btn" type="button" onclick="location.href='${pageContext.request.contextPath}/seller/fundings/create-step1'">이전</button>
 		<button class="btn" type="submit">다음</button>
 	</div>
-
 </form>
 
-<!-- 모달 영역 -->
+<!-- 모달 -->
 <div id="resultModal">
 	<p id="modalMsg">판매가는 정가보다 높을 수 없습니다.</p>
 	<button id="closeModalBtn">확인</button>
 </div>
-<!-- 모달 배경 -->
 <div id="modalBackdrop"></div>

--- a/src/main/webapp/WEB-INF/views/pages/seller/product/productDetail.jsp
+++ b/src/main/webapp/WEB-INF/views/pages/seller/product/productDetail.jsp
@@ -1,11 +1,10 @@
 <%@ include file="/WEB-INF/views/common/init.jsp"%>
 <%@ page language="java" contentType="text/html; charset=UTF-8"
 	pageEncoding="UTF-8"%>
-
 <link rel="stylesheet"
 	href="${cpath}/resources/css/pages/seller/productDetail.css">
 <input type="hidden" id="productId" value="${productDTO.productId}" />
-
+<input type="hidden" id="redirectUrl" value="${redirectUrl}" />
 <div class="main-title-box">
 	<div class="main-title">상점에 새롭게 추가할 메뉴에 대한 정보를 입력해주세요</div>
 </div>
@@ -32,8 +31,7 @@
 	</div>
 	<div class="content-input" id="image-preview-container">
 		<div class="menu-img-upload-wrapper">
-			<label for="images" class="menu-img-btn">사진 추가하기</label> 
-			<input
+			<label for="images" class="menu-img-btn">사진 추가하기</label> <input
 				type="file" id="images" name="images" multiple accept="image/*"
 				onchange="handleFiles(this.files)" />
 		</div>
@@ -110,7 +108,7 @@ function handleFiles(fileList) {
 
   document.getElementById('images').value = '';
 }
-
+const redirectUrl = document.getElementById("redirectUrl")?.value;
 function submitProduct() {
 	  const productId = document.getElementById("productId").value;
 	  const productData = {
@@ -141,14 +139,19 @@ function submitProduct() {
 	  const method = "POST";
 
 	  fetch(url, {
-	    method: method,
-	    body: formData,
-	  })
-	  .then(res => res.text())
-	  .then(msg => {
-	    alert((productId ? "수정" : "등록") + " 결과: " + msg);
-	    
-	  })
+		  method: "POST",
+		  body: formData
+		})
+		.then(res => res.text())
+		.then(msg => {
+		  alert((productId ? "수정" : "등록") + " 결과: " + msg);
+
+		  if (redirectUrl) {
+		    location.href = redirectUrl;
+		  } else {
+		    location.href = `${cpath}/seller/product`;
+		  }
+		})
 	  .catch(err => alert("오류: " + err));
 	}
 


### PR DESCRIPTION
## 📌 PR 제목
메뉴 수정 후 기존 선택 유지 및 리다이렉트 개선

## ✨ 주요 변경 사항
- 메뉴 수정 후 이전 페이지로 돌아왔을 때, 해당 메뉴가 자동 선택되도록 URL 파라미터(`selectedProductId`) 기반 처리 추가
- `existMenu.jsp`, `normalFunding.jsp`의 스크립트 통일 및 중복 제거
- 리다이렉트 시 URL이 잘리는 문제 수정 (`+` 연산 대신 `encodeURIComponent()` 적용)

## 🔎 관련 이슈
- closes #299 

## 🧪 테스트 결과
- [x] 메뉴 수정 후 자동 선택 정상 작동
- [x] 수정 → 리턴 경로 (`redirect` 파라미터) 정상 유지됨
